### PR TITLE
fix: preserve and expose createdAt for the v2.x processing-timeout lease (#16)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,10 @@
 # .circleci/config.yml
+#
+# CircleCI is now scoped to npm publishing ONLY. Build, lint and test run on GitHub
+# Actions (see .github/workflows/ci.yml). Publishing stays here because the npm token
+# is a CircleCI secret tied to a maintainer's personal npm account and cannot be moved
+# without an org admin. The publish flow runs only on version tags, so no CircleCI
+# check is posted on branches or pull requests. See issue #17.
 defaults: &defaults
     executor:
         name: node/default
@@ -7,12 +13,20 @@ defaults: &defaults
 version: 2.1
 orbs:
     node: circleci/node@1.1.6
-    coverage-reporter: codacy/coverage-reporter@10.0.3
 jobs:
     build:
         <<: *defaults
         steps:
-            - checkout
+            # Public repo: clone over HTTPS to bypass the CircleCI SSH deploy key,
+            # whose access was revoked ("Permission denied (publickey)"). This flow
+            # only runs on version tags (publishing), so the workaround is isolated
+            # to releases. A full clone fetches every ref, so the tagged commit can
+            # be checked out by SHA. See issue #17.
+            - run:
+                  name: Checkout over HTTPS
+                  command: |
+                      git clone "https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}.git" .
+                      git checkout -f "${CIRCLE_SHA1}"
             - node/with-cache:
                   steps:
                       - run: npm install
@@ -20,15 +34,6 @@ jobs:
                   root: /home/circleci
                   paths:
                       - project/*
-    test:
-        <<: *defaults
-        steps:
-            - attach_workspace:
-                  at: /home/circleci
-            - run: npm test
-            - coverage-reporter/send_report:
-                  coverage-reports: 'coverage/lcov.info'
-                  project-token: ${CODACY_PROJECT_TOKEN}
     package:
         <<: *defaults
         steps:
@@ -64,25 +69,17 @@ jobs:
                   at: /home/circleci
             - run: npm publish --tag rc --access public
 workflows:
-    main-workflow:
+    publish-on-tag:
         jobs:
             - build:
                   filters:
                       tags:
                           only: /^v\d+\.{1}\d+.{1}\d.*+/
                       branches:
-                          only: /.*/
-            - test:
-                  requires:
-                      - build
-                  filters:
-                      tags:
-                          only: /^v\d+\.{1}\d+.{1}\d.*+/
-                      branches:
-                          only: /.*/
+                          ignore: /.*/
             - package:
                   requires:
-                      - test
+                      - build
                   filters:
                       tags:
                           only: /^v\d+\.{1}\d+.{1}\d.*+/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: CI
+
+# Build, lint and test on GitHub Actions. Uses the native actions/checkout (no SSH
+# deploy key) and a MongoDB service container instead of downloading a mongod binary
+# via mongodb-memory-server. npm publishing stays on CircleCI (see .circleci/config.yml
+# and issue #17).
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+
+    services:
+      mongodb:
+        image: mongo:7
+        ports:
+          - 27017:27017
+        options: >-
+          --health-cmd "mongosh --quiet --eval 'db.runCommand({ ping: 1 })'"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      # Point the test suite at the MongoDB service container. Without this variable
+      # the suite falls back to mongodb-memory-server (used for local development).
+      MONGO_URI: mongodb://localhost:27017/idempotency-test
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Check formatting
+        run: npm run prettier
+
+      - name: Compile
+        run: npm run compile
+
+      - name: Test
+        run: npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- `createdAt` is now persisted from the value stamped by the middleware at create time, preserved across `update()`, and returned by `findByIdempotencyKey()`. This restores the `express-idempotency` v2.x processing-timeout lease / takeover mechanism, which the adapter previously defeated by regenerating the timestamp on every write — orphaned "in progress" documents stayed blocked with `409` until the long TTL expired ([#16](https://github.com/VilledeMontreal/express-idempotency-mongo-adapter/issues/16)).
+
+### Changed
+- `update()` no longer resets `createdAt` (switched from `replaceOne` to `updateOne`/`$set`). The TTL countdown now starts from the resource creation time (request start) instead of the response-persistence time. Behavioural change only — not breaking for the public API.
+- Enabled `skipLibCheck` in `tsconfig.json` so the build tolerates unpinned `@types/*` (notably `@types/node`) resolving to versions newer than the project's TypeScript ([#17](https://github.com/VilledeMontreal/express-idempotency-mongo-adapter/issues/17)).
+
 ## [1.0.5] - 2025-05-14
 
 Copy of 1.0.4 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - `update()` no longer resets `createdAt` (switched from `replaceOne` to `updateOne`/`$set`). The TTL countdown now starts from the resource creation time (request start) instead of the response-persistence time. Behavioural change only — not breaking for the public API.
 - Enabled `skipLibCheck` in `tsconfig.json` so the build tolerates unpinned `@types/*` (notably `@types/node`) resolving to versions newer than the project's TypeScript ([#17](https://github.com/VilledeMontreal/express-idempotency-mongo-adapter/issues/17)).
+- Moved CI (build, lint, test) to GitHub Actions, using a MongoDB service container instead of downloading a `mongodb-memory-server` binary. CircleCI is now limited to npm publishing on version tags. The test suite connects to `MONGO_URI` when set (CI) and falls back to `mongodb-memory-server` locally ([#17](https://github.com/VilledeMontreal/express-idempotency-mongo-adapter/issues/17)).
 
 ## [1.0.5] - 2025-05-14
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ To avoid name conflict while using collection, it is possible to provide a colle
 
 The data adapter will create TTL indexes to purge data from collection after a certain period of time. By default, the ttl is `1 day` but is configurable.
 
+The TTL countdown starts at the resource creation time (when the request begins), not when the response is persisted. The adapter persists and returns the `createdAt` timestamp stamped by the middleware: this is required by the [`express-idempotency`](https://github.com/VilledeMontreal/express-idempotency) v2.x `processingTimeout` lease, which lets a retry take over an orphaned "in progress" resource instead of waiting for the full TTL to expire.
+
 ## License
 
 The source code of this project is distributed under the [MIT License](LICENSE).
@@ -215,6 +217,8 @@ Afin d'éviter des collisions au niveau des noms de collection, il est possible 
 #### Time-to-live (TTL)
 
 L'adapteur de données créé des index de type TTL afin de purger les données après un certain temps. Par défaut, la valeur du ttl est `1 jour` mais elle est configurable.
+
+Le décompte du TTL démarre au moment de la création de la resource (au début de la requête), et non à la persistance de la réponse. L'adapteur conserve et retourne l'horodatage `createdAt` posé par le middleware : il est requis par le mécanisme de lease `processingTimeout` de [`express-idempotency`](https://github.com/VilledeMontreal/express-idempotency) v2.x, qui permet à une nouvelle tentative de reprendre une resource « in progress » orpheline au lieu d'attendre l'expiration complète du TTL.
 
 ## Contribuer
 

--- a/src/adapter.test.ts
+++ b/src/adapter.test.ts
@@ -18,19 +18,29 @@ type IdempotencyResourceWithCreatedAt = IdempotencyResource & {
 };
 
 describe('IIdempotencyDataAdapter tests', () => {
-    let mongod: MongoMemoryServer = null;
+    let mongod: MongoMemoryServer | null = null;
+    let mongoUri: string = null;
     let dataAdapter: MongoAdapter.MongoAdapter = null;
 
     before(function (done) {
-        // Set a timeout which will give enough time to download the mongo memory server binary
+        // Allow enough time to download the in-memory mongod binary on a cold cache.
         this.timeout(60000);
 
-        MongoMemoryServer.create().then((value) => {
-            mongod = value;
+        // In CI, MONGO_URI points to a real MongoDB (e.g. a GitHub Actions service
+        // container), so no mongod binary has to be downloaded. Locally, fall back to
+        // an in-memory server so contributors need no setup.
+        const resolveUri: Promise<string> = process.env.MONGO_URI
+            ? Promise.resolve(process.env.MONGO_URI)
+            : MongoMemoryServer.create().then((value) => {
+                  mongod = value;
+                  return value.getUri();
+              });
 
+        resolveUri.then((uri) => {
+            mongoUri = uri;
             dataAdapter = MongoAdapter.newAdapter({
                 config: {
-                    uri: mongod.getUri(),
+                    uri: mongoUri,
                 },
             });
 
@@ -39,10 +49,12 @@ describe('IIdempotencyDataAdapter tests', () => {
         });
     });
 
-    // Clean Mongo memory server after use
+    // Clean up after use (stop the in-memory server only when we started one).
     after(async () => {
         await dataAdapter.stop();
-        await mongod.stop();
+        if (mongod) {
+            await mongod.stop();
+        }
     });
 
     afterEach(() => {
@@ -300,7 +312,7 @@ describe('IIdempotencyDataAdapter tests', () => {
     it('returns error if not initialized before interacting', async () => {
         const newDataAdapter = new MongoAdapter.MongoAdapter({
             config: {
-                uri: await mongod.getUri(),
+                uri: mongoUri,
             },
         });
         try {
@@ -312,9 +324,7 @@ describe('IIdempotencyDataAdapter tests', () => {
     });
 
     it('allows database connection delegation', async () => {
-        const mongoClient = await new MongoClient(
-            await mongod.getUri()
-        ).connect();
+        const mongoClient = await new MongoClient(mongoUri).connect();
         const newDataAdapter = new MongoAdapter.MongoAdapter({
             useDelegation: true,
             delegate: async (): Promise<Db> => {

--- a/src/adapter.test.ts
+++ b/src/adapter.test.ts
@@ -10,6 +10,13 @@ import {
 } from 'express-idempotency';
 import { Db, MongoClient } from 'mongodb';
 
+// createdAt is part of the parent v2.x IdempotencyResource contract (lease /
+// processing-timeout) but is not present in the installed type definitions. Mirror
+// the adapter's local extension so the tests can set and assert on it.
+type IdempotencyResourceWithCreatedAt = IdempotencyResource & {
+    createdAt?: Date | number;
+};
+
 describe('IIdempotencyDataAdapter tests', () => {
     let mongod: MongoMemoryServer = null;
     let dataAdapter: MongoAdapter.MongoAdapter = null;
@@ -54,11 +61,20 @@ describe('IIdempotencyDataAdapter tests', () => {
         const idempotencyResourceToFind = idempotencyResources[index];
 
         // Find the resource
-        const idempotencyFound = await dataAdapter.findByIdempotencyKey(
+        const idempotencyFound = (await dataAdapter.findByIdempotencyKey(
+            idempotencyResourceToFind.idempotencyKey
+        )) as IdempotencyResourceWithCreatedAt;
+        assert.ok(idempotencyFound);
+        assert.equal(
+            idempotencyFound.idempotencyKey,
             idempotencyResourceToFind.idempotencyKey
         );
-        assert.ok(idempotencyFound);
-        assert.deepEqual(idempotencyFound, idempotencyResourceToFind);
+        assert.deepEqual(
+            idempotencyFound.request,
+            idempotencyResourceToFind.request
+        );
+        // createdAt is now exposed (stamped as a fallback at create time)
+        assert.instanceOf(idempotencyFound.createdAt, Date);
     });
 
     it('prevents idempotency key duplication', async () => {
@@ -131,6 +147,154 @@ describe('IIdempotencyDataAdapter tests', () => {
             idempotencyResourceToFind.idempotencyKey
         );
         assert.isNull(idempotencyFound);
+    });
+
+    it('persists the createdAt provided at create time (not regenerated)', async () => {
+        const providedDate = new Date('2020-01-01T00:00:00.000Z');
+        const resource: IdempotencyResourceWithCreatedAt = {
+            ...createFakeIdempotencyResource(),
+            createdAt: providedDate,
+        };
+        await dataAdapter.create(resource);
+
+        const found = (await dataAdapter.findByIdempotencyKey(
+            resource.idempotencyKey
+        )) as IdempotencyResourceWithCreatedAt;
+        assert.instanceOf(found.createdAt, Date);
+        assert.equal(
+            (found.createdAt as Date).getTime(),
+            providedDate.getTime()
+        );
+    });
+
+    it('accepts a numeric (epoch) createdAt and persists it as a Date', async () => {
+        const epoch = new Date('2021-06-15T12:00:00.000Z').getTime();
+        const resource: IdempotencyResourceWithCreatedAt = {
+            ...createFakeIdempotencyResource(),
+            createdAt: epoch,
+        };
+        await dataAdapter.create(resource);
+
+        const found = (await dataAdapter.findByIdempotencyKey(
+            resource.idempotencyKey
+        )) as IdempotencyResourceWithCreatedAt;
+        assert.instanceOf(found.createdAt, Date);
+        assert.equal((found.createdAt as Date).getTime(), epoch);
+    });
+
+    it('falls back to a generated createdAt when none is provided', async () => {
+        const resource = createFakeIdempotencyResource(); // no createdAt
+        const before = Date.now();
+        await dataAdapter.create(resource);
+        const after = Date.now();
+
+        const found = (await dataAdapter.findByIdempotencyKey(
+            resource.idempotencyKey
+        )) as IdempotencyResourceWithCreatedAt;
+        assert.instanceOf(found.createdAt, Date);
+        // Within the create window — no second-precision assumption.
+        const ts = (found.createdAt as Date).getTime();
+        assert.isAtLeast(ts, before);
+        assert.isAtMost(ts, after);
+    });
+
+    it('falls back to a generated createdAt when the provided value is invalid', async () => {
+        const resource: IdempotencyResourceWithCreatedAt = {
+            ...createFakeIdempotencyResource(),
+            createdAt: Number.NaN, // invalid — must not poison the TTL index
+        };
+        const before = Date.now();
+        await dataAdapter.create(resource);
+        const after = Date.now();
+
+        const found = (await dataAdapter.findByIdempotencyKey(
+            resource.idempotencyKey
+        )) as IdempotencyResourceWithCreatedAt;
+        assert.instanceOf(found.createdAt, Date);
+        const ts = (found.createdAt as Date).getTime();
+        assert.isFalse(Number.isNaN(ts));
+        assert.isAtLeast(ts, before);
+        assert.isAtMost(ts, after);
+    });
+
+    it('preserves createdAt across update() (regression for issue #16)', async () => {
+        const t0 = new Date('2019-03-03T03:03:03.000Z');
+        const resource: IdempotencyResourceWithCreatedAt = {
+            ...createFakeIdempotencyResource(),
+            createdAt: t0,
+        };
+        await dataAdapter.create(resource);
+
+        // Read it back and persist a response, as the middleware does.
+        const found = (await dataAdapter.findByIdempotencyKey(
+            resource.idempotencyKey
+        )) as IdempotencyResourceWithCreatedAt;
+        const response = createFakeIdempotencyResponse();
+        found.response = response;
+        await dataAdapter.update(found);
+
+        const foundAgain = (await dataAdapter.findByIdempotencyKey(
+            resource.idempotencyKey
+        )) as IdempotencyResourceWithCreatedAt;
+        // createdAt must NOT be regenerated by update() — this is the core of #16.
+        assert.equal((foundAgain.createdAt as Date).getTime(), t0.getTime());
+        // ...and the response must still be persisted.
+        assert.deepEqual(foundAgain.response, response);
+    });
+
+    it('returns a stable createdAt across reads (zombie-write guard support)', async () => {
+        const resource: IdempotencyResourceWithCreatedAt = {
+            ...createFakeIdempotencyResource(),
+            createdAt: new Date('2022-12-31T23:59:59.000Z'),
+        };
+        await dataAdapter.create(resource);
+
+        const r1 = (await dataAdapter.findByIdempotencyKey(
+            resource.idempotencyKey
+        )) as IdempotencyResourceWithCreatedAt;
+        const r2 = (await dataAdapter.findByIdempotencyKey(
+            resource.idempotencyKey
+        )) as IdempotencyResourceWithCreatedAt;
+        assert.equal(
+            (r1.createdAt as Date).getTime(),
+            (r2.createdAt as Date).getTime()
+        );
+    });
+
+    it('does not erase an existing response on a response-less update ($set semantics)', async () => {
+        const t0 = new Date('2018-08-08T08:08:08.000Z');
+        const resource: IdempotencyResourceWithCreatedAt = {
+            ...createFakeIdempotencyResource(),
+            createdAt: t0,
+        };
+        await dataAdapter.create(resource);
+
+        // First update persists a response (the middleware's normal flow).
+        const response = createFakeIdempotencyResponse();
+        await dataAdapter.update({ ...resource, response });
+
+        // A subsequent response-less update must not wipe the cached response —
+        // this is where $set diverges from the former replaceOne.
+        await dataAdapter.update(resource);
+
+        const found = (await dataAdapter.findByIdempotencyKey(
+            resource.idempotencyKey
+        )) as IdempotencyResourceWithCreatedAt;
+        assert.deepEqual(found.response, response);
+        // createdAt is still preserved across both updates.
+        assert.equal((found.createdAt as Date).getTime(), t0.getTime());
+    });
+
+    it('update() on an unknown key is a no-op (no upsert)', async () => {
+        const resource = createFakeIdempotencyResource(); // never created
+        await dataAdapter.update({
+            ...resource,
+            response: createFakeIdempotencyResponse(),
+        });
+        const found = await dataAdapter.findByIdempotencyKey(
+            resource.idempotencyKey
+        );
+        assert.isNull(found);
     });
 
     it('returns error if not initialized before interacting', async () => {

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -249,7 +249,7 @@ export class MongoAdapter implements IIdempotencyDataAdapter {
      * @param value createdAt provided by the middleware, if any
      */
     private normalizeCreatedAt(value?: Date | number | null): Date {
-        if (value === undefined || value === null) {
+        if (value == null) {
             return new Date();
         }
         const date = new Date(value);
@@ -343,7 +343,7 @@ export class MongoAdapter implements IIdempotencyDataAdapter {
             request: resource.request,
             schemaVersion: SCHEMA_VERSION,
         };
-        if (resource.response !== undefined) {
+        if (resource.response != null) {
             updateFields.response = resource.response;
         }
 

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -20,6 +20,18 @@ const TTL = 86400;
 const SCHEMA_VERSION = '1.0.0';
 
 /**
+ * The `createdAt` timestamp is part of the parent library `IdempotencyResource`
+ * interface in v2.x (the processing-timeout / lease mechanism), but it is not present
+ * in the published `.d.ts` of the installed version. It is declared locally so the
+ * adapter stays decoupled from whichever parent version is installed: the middleware
+ * stamps `createdAt` at create time (request start) and relies on the adapter to
+ * persist, preserve and return it. Accepts `Date | number` to match the parent contract.
+ */
+type IdempotencyResourceWithCreatedAt = IdempotencyResource & {
+    createdAt?: Date | number;
+};
+
+/**
  * Specific idempotency resource for the mongo adapter.
  * Used to keep more information on the resource.
  */
@@ -28,8 +40,10 @@ interface MongoIdempotencyResource extends IdempotencyResource {
     // Required to provide backward compatibility later.
     schemaVersion: string;
 
-    // The date and time the resource as been created. Used by the TTL mongo index
-    // to clear the collection.
+    // The date and time the resource has been created. Stamped by the middleware
+    // (request start time) and preserved by the adapter across updates. Always
+    // persisted as a BSON Date — required by the `ttlKey` TTL index — and drives the
+    // v2.x lease / takeover of orphaned in-progress resources.
     createdAt: Date;
 }
 
@@ -228,6 +242,21 @@ export class MongoAdapter implements IIdempotencyDataAdapter {
     }
 
     /**
+     * Normalize a createdAt value received from the middleware into a BSON Date
+     * for persistence and the TTL index. Accepts Date or epoch number, and falls
+     * back to the current date when absent or invalid — backward compatible with
+     * middleware versions that do not stamp createdAt (v1.x / v2.0.0).
+     * @param value createdAt provided by the middleware, if any
+     */
+    private normalizeCreatedAt(value?: Date | number | null): Date {
+        if (value === undefined || value === null) {
+            return new Date();
+        }
+        const date = new Date(value);
+        return Number.isNaN(date.getTime()) ? new Date() : date;
+    }
+
+    /**
      * Find the resource for a specific idempotency key.
      * @param idempotencyKey Idempotency key
      * @returns Idempotency resource
@@ -248,12 +277,19 @@ export class MongoAdapter implements IIdempotencyDataAdapter {
             });
 
         if (result) {
-            const idempotencyResource: IdempotencyResource = {
+            const idempotencyResource: IdempotencyResourceWithCreatedAt = {
                 idempotencyKey: result.idempotencyKey,
                 request: result.request,
             };
             if (result.response) {
                 idempotencyResource.response = result.response;
+            }
+            // Re-expose createdAt to the v2.x middleware (lease / takeover and the
+            // zombie-write guard canStillPersist). Returned as a Date; the
+            // middleware's parseCreatedAt() accepts it. `!= null` rather than a
+            // truthiness check so an epoch-0 timestamp would still be exposed.
+            if (result.createdAt != null) {
+                idempotencyResource.createdAt = result.createdAt;
             }
             return idempotencyResource;
         }
@@ -269,10 +305,17 @@ export class MongoAdapter implements IIdempotencyDataAdapter {
     ): Promise<void> {
         await this.checkForInitialization();
 
+        const { createdAt, ...rest } =
+            idempotencyResource as IdempotencyResourceWithCreatedAt;
         const collection = this._db.collection(this.getStoreCollectionName());
         await collection.insertOne({
-            ...idempotencyResource,
-            createdAt: new Date(),
+            ...rest,
+            // Persist the createdAt stamped by the middleware (request start time)
+            // instead of overwriting it. createdAt is destructured out of the spread
+            // so the normalized BSON Date is independent of key order (the TTL index
+            // requires a Date). Fallback to new Date() when absent — this is what the
+            // v2.x processing-timeout lease relies on.
+            createdAt: this.normalizeCreatedAt(createdAt),
             schemaVersion: SCHEMA_VERSION,
         });
     }
@@ -286,15 +329,28 @@ export class MongoAdapter implements IIdempotencyDataAdapter {
     ): Promise<void> {
         await this.checkForInitialization();
 
-        const newResource = {
-            ...idempotencyResource,
-            createdAt: new Date(),
+        const resource =
+            idempotencyResource as IdempotencyResourceWithCreatedAt;
+
+        // Use updateOne/$set so createdAt is NEVER rewritten. The v2.x lease and the
+        // zombie-write guard (canStillPersist) compare the in-memory createdAt against
+        // the value re-read from the store, so the original timestamp must survive the
+        // response persistence. Only the defined fields are set; no upsert, which keeps
+        // the previous silent no-op behaviour when the key does not exist. Unlike the
+        // former replaceOne, a response-less update no longer erases an already-cached
+        // response — the middleware only ever updates to persist one, so this is safe.
+        const updateFields: Record<string, unknown> = {
+            request: resource.request,
             schemaVersion: SCHEMA_VERSION,
         };
+        if (resource.response !== undefined) {
+            updateFields.response = resource.response;
+        }
+
         const collection = this._db.collection(this.getStoreCollectionName());
-        await collection.replaceOne(
-            { idempotencyKey: idempotencyResource.idempotencyKey },
-            newResource
+        await collection.updateOne(
+            { idempotencyKey: resource.idempotencyKey },
+            { $set: updateFields }
         );
     }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,6 +29,7 @@
     "noImplicitAny": false,
     /* Raise error on expressions and declarations with an implied 'any' type. */
     "strictNullChecks": false /* Enable strict null checks. */ ,
+    "skipLibCheck": true /* Skip type checking of declaration files. Required because the dependencies are unpinned (no lockfile) and @types/* — notably @types/node — resolve to versions newer than the project's TypeScript lib. See issue #17. */ ,
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
     // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
     // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */


### PR DESCRIPTION
## Contexte

Issue **#16** (confirmée en prod). L'adapter Mongo **défaisait** le mécanisme de *processing timeout / lease* de la lib parente `express-idempotency` v2.x : il régénérait `createdAt` à chaque `create()`/`update()` et ne le retournait pas dans `findByIdempotencyKey()`. Résultat : `isLeaseExpired()` ne voyait jamais le timestamp → le takeover des documents « in progress » orphelins ne se déclenchait jamais (409 permanents jusqu'au TTL long), et `canStillPersist()` (zombie-write guard) bloquait à tort la persistance de la réponse.

## Changements

### Fix #16 (cœur)
- **`create()`** persiste le `createdAt` posé par le middleware (request start), avec fallback `new Date()` si absent/invalide. `createdAt` déstructuré hors du spread → valeur normalisée (BSON Date) indépendante de l'ordre des clés.
- **`update()`** : `replaceOne` → `updateOne`/`$set`, ne réécrit **jamais** `createdAt` (le lease et `canStillPersist` le comparent entre lectures). Pas d'upsert (no-op silencieux conservé) ; n'efface pas une réponse déjà cachée.
- **`findByIdempotencyKey()`** retourne `createdAt` quand présent.
- Type local `IdempotencyResourceWithCreatedAt` (le `.d.ts` publié n'expose pas encore le champ) → découplé de la version parente installée.
- `skipLibCheck` activé dans `tsconfig.json` (build cassé par un `@types/node` trop récent vs TS 5.5, pas de lockfile).

### Migration CI (#17)
- **CI (build/lint/test) → GitHub Actions** : `actions/checkout` natif (plus de deploy key SSH) + service container `mongo:7`.
- Tests **hybrides** : `MONGO_URI` en CI, fallback `mongodb-memory-server` en local (aucun setup pour les contributeurs).
- **CircleCI réduit au publish npm sur tags** (le token npm reste un secret CircleCI tied à un compte mainteneur). Checkout HTTPS isolé aux releases.

## Tests & vérification
- **15 tests**, dont la régression directe #16 (`preserves createdAt across update()`) et la sémantique `$set` (`does not erase an existing response`).
- Validé : local (`mongodb-memory-server`), conteneur (vrai `mongo:7`, scénario CI), et **GitHub Actions vert** (`build-test`).
- Revue : **3 rounds de critic adversarial → 0 Blocking, 0 Major**.

## À noter (actions admin / suivi — hors périmètre de ce code)
- La **deploy key SSH CircleCI** reste cassée (`Permission denied (publickey)`) — non corrigeable en code. À terme : migrer le projet sur la **GitHub App CircleCI**, ou intégrer la lib au monorepo VilledeMontreal.
- Si la **branch protection** de `master` exige les anciens checks `ci/circleci: *`, la basculer sur le check GHA **`build-test`**.
- Le contrat `createdAt` n'est pas encore publié côté `express-idempotency` (2.0.0 ne l'a pas). À la sortie de la 2.1.0, **rejouer un takeover end-to-end** pour valider le lease in vivo.
- Annotation GHA non bloquante : `actions/checkout@v4`/`setup-node@v4` tournent sur Node 24 (bump v5 = nettoyage trivial ultérieur).