### PR TITLE
ci: upload test coverage to Codacy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,3 +57,14 @@ jobs:
 
       - name: Test
         run: npm test
+
+      # Coverage upload runs only on pushes to the upstream repo: secrets are not
+      # exposed to fork PRs, and the token is absent on personal forks. It never
+      # fails the build (continue-on-error) so a missing/expired token stays soft.
+      - name: Upload coverage to Codacy
+        if: ${{ github.event_name == 'push' && github.repository == 'VilledeMontreal/express-idempotency-mongo-adapter' }}
+        continue-on-error: true
+        uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699 # v1.3.0
+        with:
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          coverage-reports: coverage/lcov.info


### PR DESCRIPTION
## Why

The Codacy **coverage badge shows 0%/“-”** for this repo while the sibling `express-idempotency` shows 95.58%. Root cause: `ci.yml` never uploaded the coverage report to Codacy — the upload step was missing here (it exists in the main library).

`nyc` already produces `coverage/lcov.info` (`.nycrc` → `reporter: lcov`); the data was just never sent.

## What

Add the **Upload coverage to Codacy** step to the `build-test` job, mirroring `express-idempotency`:

- Runs **only on pushes to the upstream repo** (`if: event_name == 'push' && repository == 'VilledeMontreal/express-idempotency-mongo-adapter'`) — fork PRs have no access to the secret.
- **`continue-on-error: true`** — a missing/expired token never fails the build.
- Action **pinned to commit SHA** (`codacy/codacy-coverage-reporter-action@…# v1.3.0`).

The `CODACY_PROJECT_TOKEN` secret already exists on the repo, so coverage will start reporting on the next push to `master` and the badge will reflect the real value.